### PR TITLE
`+` should unify buffer types

### DIFF
--- a/python/aghast/version.py
+++ b/python/aghast/version.py
@@ -4,7 +4,7 @@
 
 import re
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
When you add two histograms, one with integer binning and another with floating point binning, you want to get floating point binning out.