### PR TITLE
Add PyPI and supported Python badges to README

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -4,6 +4,9 @@
 
 [![Build Status](https://travis-ci.org/scikit-hep/aghast.svg?branch=master)](https://travis-ci.org/scikit-hep/aghast) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/scikit-hep/aghast/master?urlpath=lab/tree/binder%2Ftutorial.ipynb)
 
+[![PyPI version](https://badge.fury.io/py/aghast.svg)](https://badge.fury.io/py/aghast)
+[![Supported Python versionss](https://img.shields.io/pypi/pyversions/aghast.svg)](https://pypi.org/project/aghast/)
+
 Aghast is a histogramming library that does not fill histograms and does not plot them. Its role is behind the scenes, to provide better communication between histogramming libraries.
 
 Specifically, it is a structured representation of **ag**gregated, **h**istogram-like **st**atistics as sharable "ghasts." It has all of the "bells and whistles" often associated with plain histograms, such as number of entries, unbinned mean and standard deviation, bin errors, associated fit functions, profile plots, and even simple ntuples (needed for unbinned fits or machine learning applications). [ROOT](https://root.cern.ch/root/htmldoc/guides/users-guide/Histograms.html) has all of these features; [Numpy](https://docs.scipy.org/doc/numpy/reference/generated/numpy.histogram.html) has none of them.

--- a/python/README.md
+++ b/python/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://travis-ci.org/scikit-hep/aghast.svg?branch=master)](https://travis-ci.org/scikit-hep/aghast) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/scikit-hep/aghast/master?urlpath=lab/tree/binder%2Ftutorial.ipynb)
 
 [![PyPI version](https://badge.fury.io/py/aghast.svg)](https://badge.fury.io/py/aghast)
-[![Supported Python versionss](https://img.shields.io/pypi/pyversions/aghast.svg)](https://pypi.org/project/aghast/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/aghast.svg)](https://pypi.org/project/aghast/)
 
 Aghast is a histogramming library that does not fill histograms and does not plot them. Its role is behind the scenes, to provide better communication between histogramming libraries.
 


### PR DESCRIPTION
The PyPI badge [![PyPI version](https://badge.fury.io/py/aghast.svg)](https://badge.fury.io/py/aghast) shows the current release on PyPI that one would get from

```
pip install aghast
```

and the supported Python versions badge [![Supported Python versionss](https://img.shields.io/pypi/pyversions/aghast.svg)](https://pypi.org/project/aghast/) shows the compatible Python versions that are listed on PyPI.